### PR TITLE
bindOrder optimizations

### DIFF
--- a/select2.sortable.js
+++ b/select2.sortable.js
@@ -51,7 +51,7 @@
 			if(args.length === 0 || typeof(args[0]) === 'object')
 			{
 				var defaultOptions = {
-					bindOrder       : 'form_submit', // or sortstop
+					bindOrder       : 'formSubmit', // or sortableStop
 					sortableOptions : {
 						placeholder : 'ui-state-highlight',
 						items       : 'li:not(.select2-search-field)',
@@ -73,17 +73,14 @@
 					$select2choices.sortable(options.sortableOptions);
 
 					switch(options.bindOrder){
-						case 'sortstop':
+						case 'sortableStop':
 							// apply options ordering in sortstop event
 							$select2choices.on("sortstop.select2sortable", function( event, ui ) {
 								$select.select2SortableOrder();
 							});
-							break;
-						case 'form_submit':
-							// apply options ordering in form submit
-							$select.closest('form').unbind('submit.select2sortable').on('submit.select2sortable', function(){
-								$select.select2SortableOrder();
-							});
+							$select.on('change', function(e){
+					                	$(this).select2SortableOrder();
+					               	})
 							break;
 						default:
 							// apply options ordering in form submit


### PR DESCRIPTION
Changed bindOrder values to be more consistent, both camelcased.
If you prefer you can use form_submit and sortable_stop, it's a matter of taste.

Added a select2SortableOrder() on original select change event in sortableStop binding, this is needed when you add the last option without sorting and than the first option without sorting. If you do not call select2SortableOrder() on change the values will be sent in the wrong order.

Removed a switch block, if bindOrder is not sortableStop it will fallback to form binding anyway.

I made this pull request on the fly editing the file in Github(I'm in hurry today) copying parts of my working code.
I didn't tested this mixed version but I'm confident it will works :), if you can't test it I will let you know if it works as soon as possible.
